### PR TITLE
chore(seceng-407): remove commented exceptional.io API key from test

### DIFF
--- a/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
+++ b/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
@@ -99,9 +99,6 @@ public class EndToEndStoppingTest {
                                 .withStatusCode(200)
                                 .withBody("Success!")
                 );
-        // final String url = "https://www.exceptional.io/api/errors?" +
-        // "api_key="+"9848f38fb5ad1db0784675b75b9152c87dc1eb95"+"&protocol_version=6";
-
         final String url = "http://127.0.0.1:" + mockServerPort + "/success";
         final String[] sites = { url };// "https://www.google.com.ua"};//"https://exceptional.io"};//"http://www.google.com.ua"};
         for (final String site : sites) {


### PR DESCRIPTION
Removes commented-out lines containing exceptional.io URL and API key from `EndToEndStoppingTest.java`.

**Context:** SECENG-407. Researcher reported the key; we validated that it appears only in comments (never executed) and that exceptional.io is defunct. Not a vulnerability; removal is hygiene only.